### PR TITLE
use grab instead of frob to remove redeemed collateral from urn

### DIFF
--- a/src/mgr.sol
+++ b/src/mgr.sol
@@ -235,7 +235,9 @@ contract TinlakeManager is LibNote {
         uint dart = mul(ONE, payBack) / rate;
         require(dart <= 2 ** 255, "TinlakeManager/overflow");
         vat.frob(ilk, address(this), address(this), address(this),
-                 -int(dropReturned), -int(dart));
+                 0, -int(dart));
+        vat.grab(ilk, address(this), address(this), address(this),
+                 -int(dropReturned), 0);
         vat.slip(ilk, address(this), -int(dropReturned));
 
         // Return possible remainder to the owner


### PR DESCRIPTION
If the urn is undercollateralized ([not safe](https://github.com/makerdao/dss/blob/master/src/vat.sol#L187)), it is currently not possible to call `unwind` even though this is effectively de-risking the position of the manager. But we still want to decrease the `ink` of the urn because redeeming is essentially "using up" collateral, which needs to be accounted for.
Since the mgr is authed on the vat we can ensure that the ink is removed by a call to grab instead of frob.