### PR TITLE
More conservative cage procedure

### DIFF
--- a/src/mgr.sol
+++ b/src/mgr.sol
@@ -262,7 +262,8 @@ contract TinlakeManager is LibNote {
     }
 
     function recover(uint endEpoch) public note {
-        require(!glad && live, "TinlakeManager/not-written-off");
+        require(!glad, "TinlakeManager/not-written-off");
+
         (uint recovered, , ,) = pool.disburse(endEpoch);
         uint payBack = min(recovered, tab / ONE);
         daiJoin.join(address(vow), payBack);
@@ -270,15 +271,14 @@ contract TinlakeManager is LibNote {
         dai.transfer(owner, dai.balanceOf(address(this)));
     }
 
-    // --- Global settlement ---
-    function take(uint endEpoch) public note ownerOnly {
-        require(!live, "TinlakeManager/not-live");
-        pool.disburse(endEpoch);
-        dai.transfer(msg.sender, dai.balanceOf(address(this)));
-    }
-
     function cage() external note {
+        if (tab == 0) {
+            (, uint256 art) = vat.urns(ilk, address(this));
+            (, uint rate, , ,) = vat.ilks(ilk);
+            tab = mul(rate, art);
+        }
         require(wards[msg.sender] == 1 || vat.live() == 0, "TinlakeManager/not-authorized");
         live = false;
+        glad = false;
     }
 }

--- a/src/test/mgr-unit.t.sol
+++ b/src/test/mgr-unit.t.sol
@@ -161,6 +161,8 @@ contract TinlakeManagerUnitTest is DSTest {
     function cage() public {
         mgr.cage();
         assert(!mgr.live());
+        assert(!mgr.glad());
+ 
     }
 
     function changeOwner() public {
@@ -309,19 +311,6 @@ contract TinlakeManagerUnitTest is DSTest {
         assert(!mgr.glad());
     }
 
-    function take(uint endEpoch, uint redeemedDAI) public {
-        // dai balance of mgr owner before take
-        uint ownerBalanceDAI = dai.balanceOf(self);
-        // mint dai that can be disbursed
-        dai.mint(seniorOperator_, redeemedDAI); // mint enough DAI for redemptio
-        seniorOperator.setDisburseValues(redeemedDAI, 0, 0, 0); 
-
-        mgr.take(endEpoch);
-
-        // assert transfer to owner successfull
-        assertEq(dai.balanceOf(self), add(ownerBalanceDAI, redeemedDAI));
-    }
-
     function migrate() public {
          // deploy new mgr
         TinlakeManager newMgr = new TinlakeManager(address(vat),
@@ -400,22 +389,6 @@ contract TinlakeManagerUnitTest is DSTest {
         // remove auth for mgr
         mgr.deny(self);
         migrate();
-    }
-
-    function testTake(uint endEpoch, uint redeemedDAI) public {
-        // set live to false, call cage
-        cage();
-        take(endEpoch, redeemedDAI);
-    }
-
-    function testFailTakeNotOwner(uint endEpoch, uint redeemedDAI) public {
-        // change ownership of mgr
-        testChangeOwner();
-        testTake(endEpoch, redeemedDAI);
-    }
-
-    function testFailTakeIsLive(uint endEpoch, uint redeemedDAI) public { 
-        take(endEpoch, redeemedDAI);
     }
     
     function testSink(uint art, uint ink) public {


### PR DESCRIPTION
In global settlement, drop cannot go through the normal redemption
process due to legal reasons. Instead, we manually settle the urn
in the traditional way.
Previously, the `take` method would have caused dai generated from
drop to be redeemed on behalf of other collateral types. This change
isolates the potential damage to the single drop urn holder.