### PR TITLE
fix: mip21 require liq.cull call before mgr.cull

### DIFF
--- a/src/mgr.sol
+++ b/src/mgr.sol
@@ -238,6 +238,12 @@ contract TinlakeManager {
         else if (what == "owner") {
             owner = data;
         }
+        else if (what == "pool") {
+            pool = RedeemLike(data);
+        }
+        else if (what == "tranche") {
+            tranche = data;
+        }
         else revert("TinlakeMgr/file-unknown-param");
     }
 

--- a/src/mgr.sol
+++ b/src/mgr.sol
@@ -64,7 +64,7 @@ interface MIP21UrnLike {
 }
 
 interface MIP21LiquidationLike {
-  function ilks(bytes32 ilk) external returns (string memory, address, uint48, uint48);
+    function ilks(bytes32 ilk) external returns (string memory, address, uint48, uint48);
 }
 
 contract TinlakeManager {
@@ -125,10 +125,10 @@ contract TinlakeManager {
     address public owner;
 
     constructor(address dai_,   address daiJoin_,
-                address drop_,  address pool_,
-                address owner_, address tranche_,
-                address end_,   address vat_
-                ) public {
+        address drop_,  address pool_,
+        address owner_, address tranche_,
+        address end_,   address vat_
+    ) public {
 
         dai = GemLike(dai_);
         daiJoin = JoinLike(daiJoin_);
@@ -281,6 +281,7 @@ contract TinlakeManager {
 
         // Return possible remainder to the owner
         dai.transfer(owner, dai.balanceOf(address(this)));
+        tab = sub(tab, mul(payBack, RAY));
         emit Unwind(payBack);
     }
 
@@ -289,6 +290,9 @@ contract TinlakeManager {
     function cull() public {
         require(!safe && glad && live, "TinlakeMgr/bad-state");
         bytes32 ilk = GemJoinLike(urn.gemJoin()).ilk();
+
+        (uint256 ink, uint256 art) = vat.urns(ilk, address(urn));
+        require(ink == 0 && art == 0, "TinlakeMgr/not-written-off");
 
         (,, uint48 tau, uint48 toc) = liq.ilks(ilk);
         require(toc != 0, "TinlakeMgr/not-liquidated");

--- a/src/mgr.sol
+++ b/src/mgr.sol
@@ -273,15 +273,15 @@ contract TinlakeManager {
 
         (, uint256 art) = vat.urns(ilk, address(urn));
         (, uint256 rate, , ,) = vat.ilks(ilk);
-        tab = mul(art, rate);
+        uint256 tab_ = mul(art, rate);
 
-        uint256 payBack = min(redeemed, divup(tab, RAY));
+        uint256 payBack = min(redeemed, divup(tab_, RAY));
         dai.transferFrom(address(this), address(urn), payBack);
         urn.wipe(payBack);
 
         // Return possible remainder to the owner
         dai.transfer(owner, dai.balanceOf(address(this)));
-        tab = sub(tab, mul(payBack, RAY));
+        tab = sub(tab_, mul(payBack, RAY));
         emit Unwind(payBack);
     }
 

--- a/src/test/mgr-unit.t.sol
+++ b/src/test/mgr-unit.t.sol
@@ -478,8 +478,9 @@ contract TinlakeManagerUnitTest is DSTest, DSMath {
         tell();
         uint tab = mgr.tab();
 
-        unwind(wad / 2); // Payback half of the loan
-        assertEq(tab/2, mgr.tab());
+        uint128 repayAmount = wad/2;
+        unwind(repayAmount); // Payback half of the loan
+        assertEq(tab-repayAmount*RAY, mgr.tab());
     }
 
     function testFailUnwindGlobalSettlement(uint128 wad) public {

--- a/src/test/mocks/vat.sol
+++ b/src/test/mocks/vat.sol
@@ -32,7 +32,7 @@ contract VatMock is Mock, Auth {
 
     function urns(bytes32, address) external returns (uint, uint) {
         calls["urns"]++;
-        return (values_uint["ink"], values_uint["art"]);
+        return (values_return["urns_ink"], values_return["urns_art"]);
     }
 
     function hope(address usr) external {


### PR DESCRIPTION
- it should be not possible to call `mgr.cull` before `liq.cull`
   - mgr. cull method requires `require(ink == 0 && art == 0, "TinlakeMgr/not-written-off");`
- correct tab calculation in unwind
  - the current repayment amount needs to be considered