### PR TITLE
chore: dapp uninstall tinlake

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "lib/dss"]
 	path = lib/dss
 	url = https://github.com/centrifuge/dss.git
-[submodule "lib/tinlake"]
-	path = lib/tinlake
-	url = https://github.com/centrifuge/tinlake
 [submodule "lib/rwa-example"]
 	path = lib/rwa-example
 	url = https://github.com/livnev/rwa-example


### PR DESCRIPTION
- lib dependency is not required anymore